### PR TITLE
Fix how the IJ Plugin searches for pull request URLs 

### DIFF
--- a/intellij-plugin/CHANGELOG.md
+++ b/intellij-plugin/CHANGELOG.md
@@ -8,17 +8,22 @@
 
 ### Added
 
-* Added 'Run' gutter action in *.df.kts files that will run the Dangerfile directly in the IDE
-* Added integration with GitHub / Git4Idea plugins to automatically configure run actions.
+- Added 'Run' gutter action in *.df.kts files that will run the Dangerfile directly in the IDE
+- Added integration with GitHub / Git4Idea plugins to automatically configure run actions.
 
 ## [2.0.1]
 
 ### Changed
 
-* Bumping version danger-kotlin that doesn't break
+- Bumping version danger-kotlin that doesn't break
 
 ## [2.0.0]
 
 ### Changed
 
-* Initial release
+- Initial release
+
+[Unreleased]: https://github.com/r0adkll/danger-kotlin/compare/v2.0.2...HEAD
+[2.0.2]: https://github.com/r0adkll/danger-kotlin/compare/v2.0.1...v2.0.2
+[2.0.1]: https://github.com/r0adkll/danger-kotlin/compare/v2.0.0...v2.0.1
+[2.0.0]: https://github.com/r0adkll/danger-kotlin/commits/v2.0.0

--- a/intellij-plugin/src/main/kotlin/com/r0adkll/danger/action/CreateDangerRunAction.kt
+++ b/intellij-plugin/src/main/kotlin/com/r0adkll/danger/action/CreateDangerRunAction.kt
@@ -40,8 +40,6 @@ class CreateDangerRunAction(private val dangerEntrypointElement: PsiElement) : A
     configuration.isEditBeforeRun = true
 
     // Pass the configuration on to it.
-    // TODO: Add ability to detect when no command is passed, so the user
-    //  is prompted to edit a new config.
     (configuration.configuration as DangerRunConfiguration).applyOptions { options ->
       options.dangerFilePath = dangerFile.absolutePathString()
     }

--- a/intellij-plugin/src/main/kotlin/com/r0adkll/danger/action/DangerRunAction.kt
+++ b/intellij-plugin/src/main/kotlin/com/r0adkll/danger/action/DangerRunAction.kt
@@ -69,7 +69,8 @@ class DangerRunAction(
         options.prUrl = command.url
       }
       if (command is Command.Local) {
-        options.stagedOnly = command.useStagedChanges
+        //options.stagedOnly = command.useStagedChanges
+        options.baseBranch = command.base
       }
     }
 

--- a/intellij-plugin/src/main/kotlin/com/r0adkll/danger/action/DangerRunAction.kt
+++ b/intellij-plugin/src/main/kotlin/com/r0adkll/danger/action/DangerRunAction.kt
@@ -68,7 +68,7 @@ class DangerRunAction(
       }
       if (command is Command.Local) {
         // TODO: Need to test this more
-        //options.stagedOnly = command.useStagedChanges
+        // options.stagedOnly = command.useStagedChanges
         options.baseBranch = command.base
       }
     }

--- a/intellij-plugin/src/main/kotlin/com/r0adkll/danger/action/DangerRunAction.kt
+++ b/intellij-plugin/src/main/kotlin/com/r0adkll/danger/action/DangerRunAction.kt
@@ -60,8 +60,6 @@ class DangerRunAction(
     runManager.addConfiguration(configuration)
 
     // Pass the configuration on to it.
-    // TODO: Add ability to detect when no command is passed, so the user
-    //  is prompted to edit a new config.
     (configuration.configuration as DangerRunConfiguration).applyOptions { options ->
       options.dangerFilePath = dangerFile.absolutePathString()
       options.command = command.option
@@ -69,6 +67,7 @@ class DangerRunAction(
         options.prUrl = command.url
       }
       if (command is Command.Local) {
+        // TODO: Need to test this more
         //options.stagedOnly = command.useStagedChanges
         options.baseBranch = command.base
       }

--- a/intellij-plugin/src/main/kotlin/com/r0adkll/danger/services/GithubService.kt
+++ b/intellij-plugin/src/main/kotlin/com/r0adkll/danger/services/GithubService.kt
@@ -58,7 +58,7 @@ class GithubService(private val project: Project) : CiProvider {
       ghRepoPath?.let { GHRepositoryCoordinates(ghServerPath, it) } ?: return null
 
     thisLogger()
-      .warn(
+      .info(
         """
           Repo Path Info:
             remoteUrl = $remoteUrl,
@@ -88,19 +88,13 @@ class GithubService(private val project: Project) : CiProvider {
     val apiExecutor = GithubApiRequestExecutor.Factory.getInstance().create(ghServerPath, token)
 
     thisLogger()
-      .warn(
+      .info(
         "Searching pull request @ ${request.url}, for ${trackedBranch.nameForRemoteOperations}"
       )
 
     return withContext(Dispatchers.IO) {
       try {
         val response = apiExecutor.execute(request)
-
-        response.items.forEach { pr ->
-          this@GithubService.thisLogger()
-            .warn("PR Result: ${pr.id}, ${pr.number}, ${pr.nodeId}")
-        }
-
         val pullRequestId = response.items.firstOrNull()?.number
         if (pullRequestId != null) {
           // attempt to construct the PR url from the found number, the Github plugin keeps the API

--- a/intellij-plugin/src/main/kotlin/com/r0adkll/danger/services/GithubService.kt
+++ b/intellij-plugin/src/main/kotlin/com/r0adkll/danger/services/GithubService.kt
@@ -88,9 +88,7 @@ class GithubService(private val project: Project) : CiProvider {
     val apiExecutor = GithubApiRequestExecutor.Factory.getInstance().create(ghServerPath, token)
 
     thisLogger()
-      .info(
-        "Searching pull request @ ${request.url}, for ${trackedBranch.nameForRemoteOperations}"
-      )
+      .info("Searching pull request @ ${request.url}, for ${trackedBranch.nameForRemoteOperations}")
 
     return withContext(Dispatchers.IO) {
       try {
@@ -124,7 +122,7 @@ class GithubService(private val project: Project) : CiProvider {
         "DANGER_GITHUB_API_TOKEN" to token,
         "DANGER_GITHUB_HOST" to ghAccount.server.toUrl(),
         "DANGER_GITHUB_API_BASE_URL" to ghAccount.server.toApiUrl(),
-        "CI_PROVIDER" to "Github"
+        "CI_PROVIDER" to "Github",
       )
     }
 

--- a/intellij-plugin/src/main/kotlin/com/r0adkll/danger/services/GithubService.kt
+++ b/intellij-plugin/src/main/kotlin/com/r0adkll/danger/services/GithubService.kt
@@ -13,6 +13,7 @@ import org.jetbrains.plugins.github.api.GHRepositoryCoordinates
 import org.jetbrains.plugins.github.api.GithubApiRequestExecutor
 import org.jetbrains.plugins.github.api.GithubApiRequests
 import org.jetbrains.plugins.github.api.GithubServerPath
+import org.jetbrains.plugins.github.api.data.GithubIssueState
 import org.jetbrains.plugins.github.authentication.GHAccountsUtil
 import org.jetbrains.plugins.github.authentication.accounts.GithubAccount
 import org.jetbrains.plugins.github.util.GHCompatibilityUtil
@@ -55,8 +56,9 @@ class GithubService(private val project: Project) : CiProvider {
     val ghRepoPath = GithubUrlUtil.getUserAndRepositoryFromRemoteUrl(remoteUrl)
     val repoCoordinates =
       ghRepoPath?.let { GHRepositoryCoordinates(ghServerPath, it) } ?: return null
+
     thisLogger()
-      .info(
+      .warn(
         """
           Repo Path Info:
             remoteUrl = $remoteUrl,
@@ -65,6 +67,7 @@ class GithubService(private val project: Project) : CiProvider {
             serverPath.toApiUrl = ${ghServerPath.toApiUrl()},
             repoPath = $ghRepoPath,
             repoCoordinates = $repoCoordinates
+            headRef = ${trackedBranch.nameForRemoteOperations},
         """
           .trimIndent()
       )
@@ -72,7 +75,8 @@ class GithubService(private val project: Project) : CiProvider {
     val request =
       GithubApiRequests.Repos.PullRequests.find(
         repository = repoCoordinates,
-        headRef = trackedBranch.nameForRemoteOperations,
+        state = GithubIssueState.open,
+        headRef = "${repoCoordinates.repositoryPath.owner}:${trackedBranch.nameForRemoteOperations}",
       )
 
     val token = GHCompatibilityUtil.getOrRequestToken(ghAccount, project)
@@ -84,13 +88,19 @@ class GithubService(private val project: Project) : CiProvider {
     val apiExecutor = GithubApiRequestExecutor.Factory.getInstance().create(ghServerPath, token)
 
     thisLogger()
-      .debug(
-        "Searching pull request @ ${repoCoordinates.toUrl()}, for ${trackedBranch.nameForRemoteOperations}"
+      .warn(
+        "Searching pull request @ ${request.url}, for ${trackedBranch.nameForRemoteOperations}"
       )
 
     return withContext(Dispatchers.IO) {
       try {
         val response = apiExecutor.execute(request)
+
+        response.items.forEach { pr ->
+          this@GithubService.thisLogger()
+            .warn("PR Result: ${pr.id}, ${pr.number}, ${pr.nodeId}")
+        }
+
         val pullRequestId = response.items.firstOrNull()?.number
         if (pullRequestId != null) {
           // attempt to construct the PR url from the found number, the Github plugin keeps the API
@@ -116,7 +126,12 @@ class GithubService(private val project: Project) : CiProvider {
       val token =
         GHCompatibilityUtil.getOrRequestToken(ghAccount, project) ?: return@withContext emptyMap()
 
-      mapOf("DANGER_GITHUB_API_TOKEN" to token, "CI_PROVIDER" to "Github")
+      mapOf(
+        "DANGER_GITHUB_API_TOKEN" to token,
+        "DANGER_GITHUB_HOST" to ghAccount.server.toUrl(),
+        "DANGER_GITHUB_API_BASE_URL" to ghAccount.server.toApiUrl(),
+        "CI_PROVIDER" to "Github"
+      )
     }
 
   /** Find the matching [GithubAccount] for the current tracked branch */


### PR DESCRIPTION
The previous impl was actually broken b/c I failed to fully read the GH rest API

This also correctly hydrates the run environment on configurations so that all the GH auth, url, etc are automatically available for your danger runs. This makes it so you don't have to configure your machines envars to authenticate danger test runs.