### PR TITLE
New Feature: Rules

### DIFF
--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/danger/DangerDSL.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/models/danger/DangerDSL.kt
@@ -1,46 +1,61 @@
 package systems.danger.kotlin.models.danger
 
-import kotlinx.serialization.*
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import systems.danger.kotlin.models.bitbucket.BitBucketCloud
 import systems.danger.kotlin.models.bitbucket.BitBucketServer
 import systems.danger.kotlin.models.git.Git
 import systems.danger.kotlin.models.github.GitHub
 import systems.danger.kotlin.models.gitlab.GitLab
 
-@Serializable internal data class DSL(val danger: DangerDSL)
+@Serializable internal data class DSL(val danger: DangerDSLModel)
 
 @Serializable
-data class DangerDSL(
+data class DangerDSLModel(
   @SerialName("github") private val _github: GitHub? = null,
   @SerialName("bitbucket_server") private val _bitBucketServer: BitBucketServer? = null,
   @SerialName("bitbucket_cloud") private val _bitBucketCloud: BitBucketCloud? = null,
   @SerialName("gitlab") private val _gitlab: GitLab? = null,
-  val git: Git,
-) {
-  val github: GitHub
+  override val git: Git,
+): DangerDSL {
+
+  override val github: GitHub
     get() = _github!!
 
-  val bitBucketServer: BitBucketServer
+  override val bitBucketServer: BitBucketServer
     get() = _bitBucketServer!!
 
-  val bitBucketCloud: BitBucketCloud
+  override val bitBucketCloud: BitBucketCloud
     get() = _bitBucketCloud!!
 
-  val gitlab: GitLab
+  override val gitlab: GitLab
     get() = _gitlab!!
 
-  val onGitHub
+  override val onGitHub
     get() = _github != null
 
-  val onBitBucketServer
+  override val onBitBucketServer
     get() = _bitBucketServer != null
 
-  val onBitBucketCloud
+  override val onBitBucketCloud
     get() = _bitBucketCloud != null
 
-  val onGitLab
+  override val onGitLab
     get() = _gitlab != null
 
-  val utils: Utils
+  override val utils: Utils
     get() = Utils()
+}
+
+interface DangerDSL {
+  val git: Git
+  val github: GitHub
+  val bitBucketServer: BitBucketServer
+  val bitBucketCloud: BitBucketCloud
+  val gitlab: GitLab
+  val onGitHub: Boolean
+  val onBitBucketServer: Boolean
+  val onBitBucketCloud: Boolean
+  val onGitLab: Boolean
+  val utils: Utils
 }

--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/rules/Rule.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/rules/Rule.kt
@@ -5,7 +5,7 @@ import systems.danger.kotlin.models.danger.DangerDSL
 class Rule(
   val id: String,
   val dependsOn: List<String>,
-  val run: DangerDSL.() -> RuleResult,
+  val run: suspend DangerDSL.() -> RuleResult,
 ) {
 
   override fun equals(other: Any?): Boolean {
@@ -27,7 +27,7 @@ class Rule(
  * of rules with early exists. For example, if the PR was made by a bot you may not want to evaluate the
  * remaining rules in your chain.
  */
-fun rule(id: String, vararg dependsOn: String, block: DangerDSL.() -> RuleResult) {
+fun rule(id: String, vararg dependsOn: String, block: suspend DangerDSL.() -> RuleResult) {
   val newRule = Rule(id, dependsOn.toList(), block)
   RuleManager.register(newRule)
 }

--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/rules/Rule.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/rules/Rule.kt
@@ -1,11 +1,17 @@
 package systems.danger.kotlin.rules
 
+import kotlinx.coroutines.CoroutineScope
 import systems.danger.kotlin.models.danger.DangerDSL
 
-class Rule(
+class RuleContext(
+  private val danger: DangerDSL,
+  private val scope: CoroutineScope,
+): DangerDSL by danger, CoroutineScope by scope
+
+internal class Rule(
   val id: String,
   val dependsOn: List<String>,
-  val run: suspend DangerDSL.() -> RuleResult,
+  val run: suspend RuleContext.() -> RuleResult,
 ) {
 
   override fun equals(other: Any?): Boolean {
@@ -23,16 +29,31 @@ class Rule(
 }
 
 /**
- * Register a new Danger rule to be executed in a specific order while also being able to interrupt the chain
- * of rules with early exists. For example, if the PR was made by a bot you may not want to evaluate the
- * remaining rules in your chain.
+ * Register a new Danger rule to be executed in a specific order while also being able to interrupt
+ * the chain of rules with early exists. For example, if the PR was made by a bot you may not want
+ * to evaluate the remaining rules in your chain.
+ *
+ * @param id the unique identifier of the rule to register. These must be unique for a given execution.
+ * @param dependsOn a list of rules that this rule depends on. These must execute before this one is allowed to.
+ * @param block the rule block to execute when [applyRules] is called
  */
-fun rule(id: String, vararg dependsOn: String, block: suspend DangerDSL.() -> RuleResult) {
+fun rule(id: String, vararg dependsOn: String, block: suspend RuleContext.() -> RuleResult) {
   val newRule = Rule(id, dependsOn.toList(), block)
   RuleManager.register(newRule)
 }
 
+/**
+ * The result of running a rule so that the manager can determine whether to stop evaluating future rules
+ * or to continue.
+ */
 sealed interface RuleResult {
+  /**
+   * Return this to continue evaluating rules in this workflow
+   */
   data object Continue : RuleResult
+
+  /**
+   * Return this to stop evaluating all rules in this workflow
+   */
   data object Exit : RuleResult
 }

--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/rules/Rule.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/rules/Rule.kt
@@ -1,0 +1,38 @@
+package systems.danger.kotlin.rules
+
+import systems.danger.kotlin.models.danger.DangerDSL
+
+class Rule(
+  val id: String,
+  val dependsOn: List<String>,
+  val run: DangerDSL.() -> RuleResult,
+) {
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as Rule
+
+    return id == other.id
+  }
+
+  override fun hashCode(): Int {
+    return id.hashCode()
+  }
+}
+
+/**
+ * Register a new Danger rule to be executed in a specific order while also being able to interrupt the chain
+ * of rules with early exists. For example, if the PR was made by a bot you may not want to evaluate the
+ * remaining rules in your chain.
+ */
+fun rule(id: String, vararg dependsOn: String, block: DangerDSL.() -> RuleResult) {
+  val newRule = Rule(id, dependsOn.toList(), block)
+  RuleManager.register(newRule)
+}
+
+sealed interface RuleResult {
+  data object Continue : RuleResult
+  data object Exit : RuleResult
+}

--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/rules/RuleGraph.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/rules/RuleGraph.kt
@@ -1,0 +1,132 @@
+package systems.danger.kotlin.rules
+
+import systems.danger.kotlin.rules.RuleGraph.Edge
+
+class RuleGraph : Iterable<RuleGraph.Vertex> {
+
+  @JvmInline
+  value class Vertex(val ruleId: String) {
+    companion object {
+      val Root = Vertex("root")
+    }
+  }
+
+  data class Edge(
+    val src: Vertex,
+    val dest: Vertex,
+  )
+
+  private val vertexMap = mutableMapOf<Vertex, MutableList<Edge>>()
+
+  fun add(rule: Rule): Vertex {
+    val vertex = Vertex(rule.id)
+
+    // An edge might have been added before the rule was, so lets make sure
+    // we don't overwrite existing edges
+    if (vertexMap[vertex] == null) {
+      vertexMap[vertex] = mutableListOf()
+    }
+
+    if (rule.dependsOn.isEmpty()) {
+      addDirectedEdge(Vertex.Root, Vertex(rule.id))
+    } else {
+      rule.dependsOn.forEach { dependsOnRuleId ->
+        addDirectedEdge(
+          // The rule this one depends on would be the source vertex
+          Vertex(dependsOnRuleId),
+
+          // This rule itself, would be the destination vertex
+          Vertex(rule.id),
+        )
+      }
+    }
+
+    return vertex
+  }
+
+  private fun addDirectedEdge(src: Vertex, dest: Vertex) {
+    val edge = Edge(src, dest)
+    if (vertexMap.containsKey(src)) {
+      vertexMap[src]?.add(edge)
+    } else {
+      // If the src vertex rule hasn't been added
+      vertexMap[src] = mutableListOf(edge)
+    }
+  }
+
+  /**
+   * Traverse this graph using a topological sorting algorithm to make sure we visit
+   * the nodes in correct order per their dependency setup.
+   *
+   * [Kahn's algorithm](https://en.wikipedia.org/wiki/Topological_sorting#Algorithms)
+   */
+  private fun sortTopologically(): List<Vertex> {
+    // Create a copy of our edge map to manipulate
+    val graph = vertexMap.toMutableMap()
+
+    val visited = mutableListOf<Vertex>()
+    val queue = ArrayDeque<Vertex>()
+
+    queue.addLast(Vertex.Root)
+
+    while (queue.isNotEmpty()) {
+      val current = queue.removeFirst()
+      visited += current
+
+      // Create a copy of the edges to iterate through
+      val edges = graph[current]?.toList() ?: emptyList()
+      for (edge in edges) {
+        // Remove the edge
+        graph[current]?.remove(edge)
+
+        // if [edge.dest] has no more incoming edges, add to queue to be visited
+        if (graph.flatMap { it.value }.none { it.dest == edge.dest }) {
+          queue.addLast(edge.dest)
+        }
+      }
+    }
+
+    val remainingEdges = graph.filter { it.value.isNotEmpty() }
+    if (remainingEdges.isNotEmpty()) {
+      throw CircularDependencyException(remainingEdges)
+    }
+
+    return visited
+  }
+
+  override fun iterator(): Iterator<Vertex> {
+    return sortTopologically().iterator()
+  }
+}
+
+data class CircularDependencyException(
+  val remainingEdges: Map<RuleGraph.Vertex, MutableList<Edge>>
+) : RuntimeException(buildString {
+  appendLine("This graph has a circular dependency:")
+  appendLine()
+
+  val edges = remainingEdges.flatMap { it.value }
+  val edgeMap = edges.associateBy { it.src }.toMutableMap()
+
+  val edgeChain = mutableListOf<RuleGraph.Vertex>()
+  val edgeQueue = ArrayDeque<Edge>()
+  val firstEdge = edges.first()
+  edgeQueue.addLast(firstEdge)
+  edgeMap.remove(firstEdge.src)
+  edgeChain.add(firstEdge.src)
+
+  while (edgeQueue.isNotEmpty()) {
+    val edge = edgeQueue.removeFirst()
+    edgeChain.add(edge.dest)
+
+    val nextEdge = edgeMap[edge.dest]
+    if (nextEdge != null) {
+      edgeMap.remove(edge.dest)
+      edgeQueue.addLast(nextEdge)
+    }
+  }
+
+  append("\t").appendLine(
+    edgeChain.joinToString(" --> ") { it.ruleId }
+  )
+})

--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/rules/RuleManager.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/rules/RuleManager.kt
@@ -1,0 +1,32 @@
+package systems.danger.kotlin.rules
+
+import systems.danger.kotlin.models.danger.DangerDSL
+import systems.danger.kotlin.warn
+
+object RuleManager {
+
+  var debug: Boolean = false
+
+  private val rules = mutableMapOf<String, Rule>()
+  private val ruleGraph = RuleGraph()
+
+  internal fun register(rule: Rule) {
+    if (rules.containsKey(rule.id)) error("Rules must have unique ids. ${rule.id} has already been added.")
+    rules[rule.id] = rule
+    ruleGraph.add(rule)
+  }
+
+  fun run(dangerDSL: DangerDSL) {
+    ruleGraph.forEach { vertex ->
+      val result = rules[vertex.ruleId]?.run?.invoke(dangerDSL)
+      if (result == RuleResult.Exit) {
+        if (debug) {
+          warn("Rule[${vertex.ruleId}] exited early. No more rules will be run in this session.")
+        }
+        return@run
+      }
+    }
+  }
+}
+
+fun DangerDSL.applyRules() = RuleManager.run(this)

--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/rules/RuleManager.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/rules/RuleManager.kt
@@ -12,14 +12,18 @@ object RuleManager {
   private val ruleGraph = RuleGraph()
 
   internal fun register(rule: Rule) {
-    if (rules.containsKey(rule.id)) error("Rules must have unique ids. ${rule.id} has already been added.")
+    if (rules.containsKey(rule.id))
+      error("Rules must have unique ids. ${rule.id} has already been added.")
     rules[rule.id] = rule
     ruleGraph.add(rule)
   }
 
-  fun run(dangerDSL: DangerDSL) = runBlocking {
+  internal fun run(dangerDSL: DangerDSL) = runBlocking {
     ruleGraph.forEach { vertex ->
-      val result = rules[vertex.ruleId]?.run?.invoke(dangerDSL)
+      if (debug) {
+        println("Evaluating Rule[${vertex.ruleId}]")
+      }
+      val result = rules[vertex.ruleId]?.run?.invoke(RuleContext(dangerDSL, this@runBlocking))
       if (result == RuleResult.Exit) {
         if (debug) {
           warn("Rule[${vertex.ruleId}] exited early. No more rules will be run in this session.")
@@ -30,4 +34,41 @@ object RuleManager {
   }
 }
 
+/**
+ * Apply all registered [Rule] in the rule chain to the current [DangerDSL] context in the order
+ * that they are registered and depend on.
+ *
+ * For example, you can register a rule like so:
+ *
+ * ```
+ * rule("pr-title-check") {
+ *   if (!github.pullRequest.title.matches(TITLE_REGEX)) {
+ *     fail("Make sure your pull request title matches the format \"JIRA-000: Description of changes\")
+ *   }
+ *
+ *   RuleResult.Continue
+ * }
+ * ```
+ *
+ * or if you need a rule to run after another, one that might exit the rule chain early
+ *
+ * ```
+ * rule("user-bot-check") {
+ *   if (github.pullRequest.user.type == GitHubUserType.BOT) {
+ *     RuleResult.Exit
+ *   } else {
+ *     RuleResult.Continue
+ *   }
+ * }
+ *
+ * rule(id = "pr-summary-validation", "user-bot-check") {
+ *   // Do stuff
+ *   RuleResult.Continue
+ * }
+ * ```
+ *
+ * @see Rule
+ * @see rule
+ * @see RuleResult
+ */
 fun DangerDSL.applyRules() = RuleManager.run(this)

--- a/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/rules/RuleManager.kt
+++ b/danger-kotlin-library/src/main/kotlin/systems/danger/kotlin/rules/RuleManager.kt
@@ -1,5 +1,6 @@
 package systems.danger.kotlin.rules
 
+import kotlinx.coroutines.runBlocking
 import systems.danger.kotlin.models.danger.DangerDSL
 import systems.danger.kotlin.warn
 
@@ -16,14 +17,14 @@ object RuleManager {
     ruleGraph.add(rule)
   }
 
-  fun run(dangerDSL: DangerDSL) {
+  fun run(dangerDSL: DangerDSL) = runBlocking {
     ruleGraph.forEach { vertex ->
       val result = rules[vertex.ruleId]?.run?.invoke(dangerDSL)
       if (result == RuleResult.Exit) {
         if (debug) {
           warn("Rule[${vertex.ruleId}] exited early. No more rules will be run in this session.")
         }
-        return@run
+        return@runBlocking
       }
     }
   }

--- a/danger-kotlin-library/src/test/kotlin/systems/danger/kotlin/rules/RuleGraphTest.kt
+++ b/danger-kotlin-library/src/test/kotlin/systems/danger/kotlin/rules/RuleGraphTest.kt
@@ -25,8 +25,7 @@ class RuleGraphTest {
     graph.forEach(nodeTraveler)
 
     // then
-    expectThat(nodeTraveler.visited)
-      .containsExactly(Root.ruleId, "0", "1", "2")
+    expectThat(nodeTraveler.visited).containsExactly(Root.ruleId, "0", "1", "2")
   }
 
   @Test
@@ -41,8 +40,7 @@ class RuleGraphTest {
     graph.forEach(nodeTraveler)
 
     // then
-    expectThat(nodeTraveler.visited)
-      .containsExactly(Root.ruleId, "0", "3", "2", "1")
+    expectThat(nodeTraveler.visited).containsExactly(Root.ruleId, "0", "3", "2", "1")
   }
 
   @Test
@@ -61,13 +59,11 @@ class RuleGraphTest {
       .get { println(this) }
   }
 
-  private fun createRule(
-    id: String,
-    vararg dependsOn: String,
-  ) = Rule(id, dependsOn.toList(), { RuleResult.Continue })
+  private fun createRule(id: String, vararg dependsOn: String) =
+    Rule(id, dependsOn.toList()) { RuleResult.Continue }
 }
 
-class NodeTraveler : (RuleGraph.Vertex) -> Unit {
+internal class NodeTraveler : (RuleGraph.Vertex) -> Unit {
 
   val visited = mutableListOf<String>()
 

--- a/danger-kotlin-library/src/test/kotlin/systems/danger/kotlin/rules/RuleGraphTest.kt
+++ b/danger-kotlin-library/src/test/kotlin/systems/danger/kotlin/rules/RuleGraphTest.kt
@@ -1,0 +1,77 @@
+package systems.danger.kotlin.rules
+
+import org.junit.Test
+import strikt.api.expectCatching
+import strikt.api.expectThat
+import strikt.assertions.containsExactly
+import strikt.assertions.isA
+import strikt.assertions.isFailure
+import strikt.assertions.message
+import systems.danger.kotlin.rules.RuleGraph.Vertex.Companion.Root
+
+class RuleGraphTest {
+
+  private val graph = RuleGraph()
+  private val nodeTraveler = NodeTraveler()
+
+  @Test
+  fun `Rules without depends execute in order added`() {
+    // given
+    graph.add(createRule("0"))
+    graph.add(createRule("1"))
+    graph.add(createRule("2"))
+
+    // when
+    graph.forEach(nodeTraveler)
+
+    // then
+    expectThat(nodeTraveler.visited)
+      .containsExactly(Root.ruleId, "0", "1", "2")
+  }
+
+  @Test
+  fun `Rules with dependencies traverse as expected`() {
+    // given
+    graph.add(createRule("0"))
+    graph.add(createRule(id = "1", "0", "3"))
+    graph.add(createRule(id = "2", "0"))
+    graph.add(createRule(id = "3"))
+
+    // when
+    graph.forEach(nodeTraveler)
+
+    // then
+    expectThat(nodeTraveler.visited)
+      .containsExactly(Root.ruleId, "0", "3", "2", "1")
+  }
+
+  @Test
+  fun `Circular dependency throws exception`() {
+    // given
+    graph.add(createRule(id = "0", "3"))
+    graph.add(createRule(id = "1", "0"))
+    graph.add(createRule(id = "2", "1"))
+    graph.add(createRule(id = "3", "2"))
+
+    // when/then
+    expectCatching { graph.forEach(nodeTraveler) }
+      .isFailure()
+      .isA<CircularDependencyException>()
+      .message
+      .get { println(this) }
+  }
+
+  private fun createRule(
+    id: String,
+    vararg dependsOn: String,
+  ) = Rule(id, dependsOn.toList(), { RuleResult.Continue })
+}
+
+class NodeTraveler : (RuleGraph.Vertex) -> Unit {
+
+  val visited = mutableListOf<String>()
+
+  override fun invoke(vertex: RuleGraph.Vertex) {
+    visited += vertex.ruleId
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,9 +15,10 @@ ktfmt = "0.54"
 ktor = "3.1.0"
 mavenPublish = "0.30.0"
 okio = "1.16.0"
-mockk = "1.10.0"
+mockk = "1.13.17"
 shadow = "9.0.0-beta9"
 spotless = "6.25.0"
+strikt = "0.34.0"
 
 [plugins]
 buildConfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }
@@ -46,7 +47,8 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+strikt = { module = "io.strikt:strikt-core", version.ref = "strikt" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 
 [bundles]
-testing = [ "junit", "mockk" ]
+testing = [ "junit", "mockk", "strikt" ]

--- a/intellij-plugin/src/main/kotlin/com/r0adkll/danger/action/DangerRunAction.kt
+++ b/intellij-plugin/src/main/kotlin/com/r0adkll/danger/action/DangerRunAction.kt
@@ -38,6 +38,7 @@ class DangerRunAction(
           description = DangerBundle.message("run.action.local.description")
           icon = AllIcons.Actions.Diff
         }
+
         is Command.PR -> {
           text = DangerBundle.message("run.action.pr.text", command.url)
           description = DangerBundle.message("run.action.pr.description")
@@ -54,7 +55,11 @@ class DangerRunAction(
     val runManager = RunManager.getInstance(event.project!!)
     val configuration =
       runManager.createConfiguration(
-        DangerBundle.message("run.action.configuration.name", dangerFile.fileName.name),
+        DangerBundle.message(
+          "run.action.configuration.name",
+          dangerFile.fileName.name,
+          command.option.name.uppercase(),
+        ),
         DangerRunConfigurationType::class.java,
       )
     runManager.addConfiguration(configuration)

--- a/intellij-plugin/src/main/resources/messages/DangerBundle.properties
+++ b/intellij-plugin/src/main/resources/messages/DangerBundle.properties
@@ -5,7 +5,7 @@ run.action.pr.description=Run 'danger pr' to test against an open PR
 run.action.create.text=Create Run Configuration
 run.action.create.description=Create a new danger run configuration
 
-run.action.configuration.name=Run {0}
+run.action.configuration.name=Run {0} as {1}
 
 run.configuration.displayName=Run Danger
 run.configuration.description=Run a Dangerilfe.df.kts


### PR DESCRIPTION
There was a need where we wanted to split your dangerfile into multiple files, but all executed in a single `danger-kotlin` call. There was also a limitation where using `@file:Import("SomeOtherScript.df.kts")` will compile and run, but won't resolve in the IDE making developing this way cumbersome and not ideal. No one wants to call red code. 

So this introduces a new feature where you can register rules, i.e. smaller `danger(args) { … }` DSL blocks that can be executed in a graphed order with dependencies. 

Writing a rule looks like this:

```kotlin
rule("pr-title-check") {
  if (!github.pullRequest.title.matches(TITLE_REGEX)) {
    fail("Make sure your pull request title matches the format \"JIRA-000: Description of changes\")
  }

  RuleResult.Continue
}
```

Where each rule returns a `RuleResult` that will dictate the continued execution of the rule chain. If you return `RuleResult.Continue` it will continue. If you return `RuleResult.Exit` the entire chain will stop (i.e. if you want to do a bot user check)

To chain rules you can use the `dependsOn` parameter of `rule` like so

```kotlin
rule("user-bot-check") {
  if (github.pullRequest.user.type == GitHubUserType.BOT) {
    RuleResult.Exit
  } else {
    RuleResult.Continue
  }
}

rule(id = "pr-summary-validation", "user-bot-check") {
  // Do stuff
  RuleResult.Continue
}
```

Then to apply all registered rules to your danger run, just call the following

```kotlin
@file:Import("other_file_1.df.kts")
@file:Import("other_file_2.df.kts")

danger(args) {
  
  // This function will execute the rule chain 
  applyRules()
}
```

And now you modularize your Dangerfile with control over your rule execution