### PR TITLE
Listen to git repo state changes to refresh internal state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## Unreleased
 - Fixed ANR when project is loading in the IDE
 - Fixed IJ run actions not working on production IDE builds.
+- Fixed IJ plugin not updating run actions when branches change
 
 # 2.0.3
 - Added a new `Rules` feature that allows you to write multiple danger rules for a single run in a graphable order.

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,7 @@ pluginName = Danger Kotlin IntelliJ Plugin
 pluginRepositoryUrl = https://github.com/r0adkll/danger-kotlin
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 242
+pluginSinceBuild = 243
 pluginUntilBuild = 251.*
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases

--- a/intellij-plugin/CHANGELOG.md
+++ b/intellij-plugin/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Fixed run actions not working on production IDE builds
 - Fixed thread blocking on project start
+- Fixed run actions not updating when branches change
 
 ## [2.0.3]
 

--- a/intellij-plugin/build.gradle.kts
+++ b/intellij-plugin/build.gradle.kts
@@ -35,9 +35,9 @@ dependencies {
   // IntelliJ Platform Gradle Plugin Dependencies Extension - read more:
   // https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html
   intellijPlatform {
-    // Meerkat RC 2 | 2024.3.2
+    // Meerkat | 2024.3.2
     // https://plugins.jetbrains.com/docs/intellij/android-studio-releases-list.html#2024
-    androidStudio("2024.3.1.11")
+    androidStudio("2024.3.1.13")
 
     // Plugin Dependencies. Uses `platformBundledPlugins` property from the gradle.properties file
     // for bundled IntelliJ Platform plugins.

--- a/intellij-plugin/src/main/kotlin/com/r0adkll/danger/services/GitService.kt
+++ b/intellij-plugin/src/main/kotlin/com/r0adkll/danger/services/GitService.kt
@@ -8,24 +8,48 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.io.toNioPathOrNull
 import com.intellij.openapi.vfs.LocalFileSystem
 import git4idea.GitBranch
+import git4idea.GitDisposable
 import git4idea.GitRemoteBranch
 import git4idea.GitUtil
 import git4idea.commands.Git
+import git4idea.repo.GitRepoInfo
 import git4idea.repo.GitRepository
+import git4idea.repo.GitRepositoryStateChangeListener
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 fun Project.gitService(): GitService = service()
 
 @Service(PROJECT)
-class GitService(private val project: Project) {
+class GitService(
+  private val project: Project,
+  private val scope: CoroutineScope,
+) {
 
   var gitRepository: GitRepository? = null
   var gitState: GitState? = null
 
   private val logger = thisLogger()
 
-  suspend fun currentGitRepository(force: Boolean = false): GitRepository? {
+  init {
+    project.messageBus.connect(GitDisposable.getInstance(project))
+      .subscribe(GitRepository.GIT_REPO_STATE_CHANGE, object : GitRepositoryStateChangeListener {
+        override fun repositoryChanged(repository: GitRepository, previousInfo: GitRepoInfo, info: GitRepoInfo) {
+          // Reload local git information
+          gitRepository = repository
+          gitState = calculateGitState(repository)
+
+          scope.launch(Dispatchers.IO) {
+            // Reload/Load pull request URL
+            project.gitHubService().findCurrentPullRequestUrl()
+          }
+        }
+      })
+  }
+
+  fun currentGitRepository(force: Boolean = false): GitRepository? {
     if (gitRepository != null && !force) return gitRepository
 
     // TODO: This seems extra clunky. Is there a better way to do this?
@@ -41,30 +65,36 @@ class GitService(private val project: Project) {
     withContext(Dispatchers.IO) {
       gitRepository = currentGitRepository(force = true)
       gitRepository?.let { repo ->
-        val trackedBranch = repo.currentBranch?.findTrackedBranch(repo)
-        val hasStagedChanges = !repo.stagingAreaHolder.isEmpty
+        calculateGitState(repo)
+          .also { gitState = it }
+      }
+    }
+
+  private fun calculateGitState(repo: GitRepository): GitState{
+    val trackedBranch = repo.currentBranch?.findTrackedBranch(repo)
+    val hasStagedChanges = !repo.stagingAreaHolder.isEmpty
+    val baseBranch =
+      repo.branches.localBranches.firstOrNull { it.name in DEFAULT_BASE_BRANCHES }
+        ?: repo.branches.remoteBranches.firstOrNull { it.name in DEFAULT_BASE_BRANCHES }
+    val isBaseBranch = repo.currentBranchName in DEFAULT_BASE_BRANCHES
+    val hasBaseBranch = repo.branches.localBranches.any { it.name in DEFAULT_BASE_BRANCHES }
+
+    val diff =
+      if (!isBaseBranch && hasBaseBranch) {
         val baseBranch =
-          repo.branches.localBranches.firstOrNull { it.name in DEFAULT_BASE_BRANCHES }
-            ?: repo.branches.remoteBranches.firstOrNull { it.name in DEFAULT_BASE_BRANCHES }
-        val isBaseBranch = repo.currentBranchName in DEFAULT_BASE_BRANCHES
-        val hasBaseBranch = repo.branches.localBranches.any { it.name in DEFAULT_BASE_BRANCHES }
+          repo.branches.localBranches.first { it.name in DEFAULT_BASE_BRANCHES }!!
+        GitUtil.getPathsDiffBetweenRefs(
+          Git.getInstance(),
+          repo,
+          baseBranch.fullName,
+          repo.currentBranch!!.fullName,
+        )
+      } else emptyList()
 
-        val diff =
-          if (!isBaseBranch && hasBaseBranch) {
-            val baseBranch =
-              repo.branches.localBranches.first { it.name in DEFAULT_BASE_BRANCHES }!!
-            GitUtil.getPathsDiffBetweenRefs(
-              Git.getInstance(),
-              repo,
-              baseBranch.fullName,
-              repo.currentBranch!!.fullName,
-            )
-          } else emptyList()
+    val hasDiffWithBase = diff.isNotEmpty()
 
-        val hasDiffWithBase = diff.isNotEmpty()
-
-        logger.debug(
-          """
+    logger.debug(
+      """
         GitRepository(
           currentBranch = {
             rev = ${repo.currentRevision},
@@ -82,22 +112,20 @@ class GitService(private val project: Project) {
           ],
         )
       """
-            .trimIndent()
-        )
+        .trimIndent()
+    )
 
-        GitState(
-            repo = repo,
-            trackedBranch = trackedBranch,
-            baseBranch = baseBranch,
-            hasStagedChanges = hasStagedChanges,
-            isBaseBranch = isBaseBranch,
-            hasBaseBranch = hasBaseBranch,
-            hasDiffWithBase = hasDiffWithBase,
-            diffs = diff.toList(),
-          )
-          .also { gitState = it }
-      }
-    }
+    return GitState(
+      repo = repo,
+      trackedBranch = trackedBranch,
+      baseBranch = baseBranch,
+      hasStagedChanges = hasStagedChanges,
+      isBaseBranch = isBaseBranch,
+      hasBaseBranch = hasBaseBranch,
+      hasDiffWithBase = hasDiffWithBase,
+      diffs = diff.toList(),
+    )
+  }
 }
 
 data class GitState(


### PR DESCRIPTION
Before, if you switched branches the Danger suggested actions wouldn't reload.

This PR adds a subscription to repo state change topic to update our internal state 