### PR TITLE
Add `@ImportDirectory` annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Refactoring how the `danger-kotlin-sdk` integrates with the main library
 - Simplified test plugin setup in the project
 - Added test fixtures for `danger-kotlin-sdk`
+- Add new `@file:ImportDirectory` kscript annotation for importing entire directories of scripts
+- Disabled all `@Import` and `@ImportDirectory` annotations when loading the script in an IDE context. See https://youtrack.jetbrains.com/issue/KTIJ-16352.
 
 # 2.0.4
 - Fixed ANR when project is loading in the IDE

--- a/danger-kotlin-kts/src/main/kotlin/systems/danger/kts/annotations/ImportDirectory.kt
+++ b/danger-kotlin-kts/src/main/kotlin/systems/danger/kts/annotations/ImportDirectory.kt
@@ -1,0 +1,41 @@
+package systems.danger.kts.annotations
+
+/**
+ * Add this annotation to import a directory of script files. This is convenient if you have a
+ * multi-file Danger setup and don't want to have to include _every_ added file by name.
+ *
+ * For example just add
+ *
+ * ```
+ * @file:ImportDirectory("rules")
+ *
+ * import …
+ *
+ * danger(args) {
+ *   //…
+ * }
+ * ```
+ *
+ * instead of
+ *
+ * ```
+ * @file:Import("rules/rule1.df.kts")
+ * @file:Import("rules/rule2.df.kts")
+ * @file:Import("rules/rule3.df.kts")
+ *
+ * import …
+ *
+ * danger(args) {
+ *   //…
+ * }
+ * ```
+ *
+ * Both this annotation and [org.jetbrains.kotlin.mainKts.Import] are disabled when loading a script
+ * into the IDE by the IntelliJ plugin as doing so breaks custom script handling. See
+ * [https://youtrack.jetbrains.com/issue/KTIJ-16352](https://youtrack.jetbrains.com/issue/KTIJ-16352)
+ * for more details.
+ */
+@Target(AnnotationTarget.FILE)
+@Repeatable
+@Retention(AnnotationRetention.SOURCE)
+annotation class ImportDirectory(vararg val paths: String)

--- a/docs/intellij-plugin.md
+++ b/docs/intellij-plugin.md
@@ -3,6 +3,12 @@
 This project provides an IDE plugin to automatically add the Danger kotlin script definition to your IDE so syntax highlighting and auto-complete work out of the box.
 The plugin will also detect the `danger(args) { … }` in your scripts and give you a gutter run action, ▶︎, that lets your test your Dangerfiles directly in the IDE.
 
+> [!NOTE]
+> All `@file:Import` and `@file:ImportDirectory` annotations are disabled under the hood when editing Dangerfile scripts
+> in your IDE. This is due to a bug in IntelliJ breaking when trying to load other scripts into scripts.
+>
+> See https://youtrack.jetbrains.com/issue/KTIJ-16352
+
 ## Git Integration
 As discussed in the [usage][] page you can run `danger-kotlin local` against your local changes in git against a base branch (_i.e. main, master, develop, etc_). The
 IntelliJ plugin will automatically detect when you are on a branch with changes against a base branch and give you a run action to test your Dangerfile

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -62,3 +62,16 @@ danger(args) {
   applyRules()
 }
 ```
+
+or use the `@file:ImportDirectory` annotation to import an entire directory of Dangerfile scripts into your main file
+
+```kotlin
+@file:ImportDirectory("rules")
+
+import systems.danger.kotlin.*
+import systems.danger.kotlin.rule.*
+
+danger(args) {
+  applyRules()
+}
+```

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -106,3 +106,46 @@ danger(args) {
   SomeOtherPlugin.doOtherStuff()
 }
 ```
+
+## Testing
+
+The SDK provides test fixtures to make it easier to test your plugins. Just import them like so:
+
+```kotlin
+dependencies {
+  testImplementation(testFixtures("com.r0adkll.danger:danger-kotlin-sdk:<latest_version>"))
+}
+```
+
+and then setup your test
+
+```kotlin
+class FailWithRetryMessageTest {
+  private val dangerContext = TestDangerContext()
+
+  @BeforeEach
+  fun setUp() {
+    ExamplePlugin.registeredContext = dangerContext
+  }
+
+  @Test
+  fun `failWithRetryMessage only posts message once`() {
+    // given
+    val fail1 = "Test failure 1"
+    val fail2 = "Test failure 2"
+
+    // when
+    ExamplePlugin.failWithRetryMessage(fail1)
+    ExamplePlugin.failWithRetryMessage(fail2)
+
+    // then
+    expectThat(dangerContext.messages)
+      .hasSize(1)
+      .containsExactly(Violation(ExamplePlugin.retryMessage))
+
+    expectThat(dangerContext.fails)
+      .hasSize(2)
+      .containsExactly(Violation(fail1), Violation(fail2))
+  }
+}
+```

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,7 @@ POM_DEVELOPER_ID=r0adkll
 POM_DEVELOPER_NAME=Drew Heavner
 POM_DEVELOPER_URL=https://github.com/r0adkll
 POM_INCEPTION_YEAR=2025
-VERSION_NAME=2.0.4
+VERSION_NAME=2.0.5
 
 # IntelliJ Plugin
 pluginGroup = com.r0adkll.danger

--- a/intellij-plugin/CHANGELOG.md
+++ b/intellij-plugin/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- New `@ImportDirectory` annotation for importing entire directories of Dangerfiles.
+
+### Fixed
+
+- Disabled `@Import` and `@ImportDirectory` annotations when editing a Dangerfile in the IDE to since these break the editor. See https://youtrack.jetbrains.com/issue/KTIJ-16352.
+
 ## [2.0.4]
 
 ### Fixed

--- a/intellij-plugin/src/main/kotlin/com/r0adkll/danger/services/DangerService.kt
+++ b/intellij-plugin/src/main/kotlin/com/r0adkll/danger/services/DangerService.kt
@@ -93,7 +93,9 @@ class DangerService(private val project: Project, private val scope: CoroutineSc
         templateClasspath = listOf(config.classPath),
         baseHostConfiguration =
           ScriptingHostConfiguration(defaultJvmScriptingHostConfiguration) {
-            getEnvironment { mapOf("projectRoot" to (project.basePath)?.let(::File)) }
+            getEnvironment {
+              mapOf("projectRoot" to (project.basePath)?.let(::File), "disableImports" to true)
+            }
           },
       )
       .firstOrNull()


### PR DESCRIPTION
Added a `@ImportDirectory` annotation that lets you import entire directories of scripts making it easier to write Dangerfile setups in a multi-file way.

For example, take the following directory Dangerfile setup

```
.danger/
└── pr/
    ├── main.df.kts
    └── rules/
        ├── rule_1.df.kts
        ├── rule_2.df.kts
        └── rule_#.df.kts
```

In the `main.df.kts` you would've had this kind of setup

**main.df.kts** 

```kotlin
@file:Import("rules/rule_1.df.kts")
@file:Import("rules/rule_2.df.kts")
@file:Import("rules/rule_3.df.kts")

import systems.danger.kotlin.*
import systems.danger.kotlin.rules.*

danger(args) {
  applyRules()
}
```

Now, you can achieve the same doing:

```kotlin
@file:ImportDirectory("rules")

import systems.danger.kotlin.*
import systems.danger.kotlin.rules.*

danger(args) {
  applyRules()
}
```

and can add/remove rules without having to keep a registry in the main file

---

Additionally due to this bug, https://youtrack.jetbrains.com/issue/KTIJ-16352, I have disabled `@Import` and `@ImportDirectory` when editing the file in the IDE, but running it should still work.