### PR TITLE
Ignore Strikt updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,9 @@
   "addLabels": [
     "renovate"
   ],
+  "ignoreDeps": [
+    "io.strikt:strikt-core"
+  ],
   "packageRules": [
     {
       "groupName": "Kotlin, KSP and Compose Compiler",


### PR DESCRIPTION
Updating strikt requires Java 17+ but compiling the script and running it with maven deps breaks